### PR TITLE
fix load、error event

### DIFF
--- a/components/preview/index.ts
+++ b/components/preview/index.ts
@@ -193,9 +193,11 @@ async function Custom() {
       };
       onError = () => {
         this.preview?.removeChild(this._loadingElement!);
+        this.dispatchEvent(new CustomEvent('error', { bubbles: true, composed: true }));
       };
       onLoad = () => {
         this.preview?.removeChild(this._loadingElement!);
+        this.dispatchEvent(new CustomEvent('load', { bubbles: true, composed: true }));
       };
       handleFile = async (file: string | File) => {
         try {


### PR DESCRIPTION
CustomElement 类使用了内部的 onLoad 和 onError 回调函数，这些回调函数仅仅移除了加载元素，但从未向 DOM 分派 load 和 error 事件。所以文档中的load和error事件并未生效

修改内容（components/preview/index.ts:194-199）：

1. onLoad 回调中增加了 this.dispatchEvent(new CustomEvent('load', { bubbles: true, composed: true }))
2. onError 回调中增加了 this.dispatchEvent(new CustomEvent('error', { bubbles: true, composed: true }))

composed: true 确保事件能穿透 Shadow DOM 向上冒泡，可以正常监听：

document.querySelector('r-preview').addEventListener('load', (e) => { ... });
document.querySelector('r-preview').addEventListener('error', (e) => { ... });